### PR TITLE
extract YouTube video id from url if needed

### DIFF
--- a/rotv_apps/program/admin.py
+++ b/rotv_apps/program/admin.py
@@ -3,6 +3,7 @@
 from django.conf import settings
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
+from yturl import video_id_from_url
 
 from ..heros.models import HeroEntry, Hero
 from .models import Episode, Program, Host, PlaylistEpisode, Playlist
@@ -59,6 +60,12 @@ class EpisodeAdmin(admin.ModelAdmin):
         queryset.update(active = True)
         self.message_user(request, u'%s opublikowanych odcinków' % queryset.count())
     publish.short_decription = u'Publikuj odcinek'
+
+    def save_model(self, request, instance, form, change):
+        instance.youtube_code = video_id_from_url(form.cleaned_data['youtube_code'])
+        instance.save()
+        form.save_m2m()
+        return instance
 
 
 class ProgramAdmin(admin.ModelAdmin):

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'django-grappelli>=2.10.1',
         'django-adminactions',
         'django-tinymce4-lite',
+        'yturl==2.0.2',
         'factory_boy',
         'tox',
         'mock',


### PR DESCRIPTION
Sometimes it is easier and faster to paste full youtube video URL instead of just it's ID. Now on saving this change in admin, the ID is extracted from the url if it was provided and replaces the url before saving. 